### PR TITLE
Handle session expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Transparent session token refresh on expiry (API error code 119) with automatic re-authorization and retry
+- Structured `Auth` and `Api` variants to `SynoError` to preserve Synology error codes
+
+### Changed
+
+- API errors now consistently preserve the Synology error code across all methods
+- `authorize()` no longer requires `&mut self` (now takes `&self`)
+- `is_authorized()` is now an `async` method
+- `SynoError` is now marked `#[non_exhaustive]`
+
+### Removed
+
+- `SynoError::SessionExpired` variant (session expiry is handled transparently via auto-retry)
+
+## [0.4.0] - 2026-02-01
+
+### Added
+
+- Ratio calculation utility function (PR #3 by @shantheone)
+
+## [0.3.0] - 2026-01-31
+
+### Changed
+
+- Request all additional fields (transfer, tracker, peer, file, detail) in task details (#1)
+
+## [0.2.0] - 2025-05-25
+
+### Added
+
+- `is_authorized()` method
+
+### Changed
+
+- Renamed `host` parameter to `url` across the API
+
+## [0.1.0] - 2025-04-13
+
+### Added
+
+- Initial release
+- Authentication with Synology API (session-based)
+- List all download tasks with detailed information
+- Get specific task details
+- Create downloads from URLs, HTTPS links, and magnet links
+- Create downloads from torrent files (multipart upload)
+- Pause, resume, complete, and delete tasks
+- Clear completed downloads
+- Human-readable file sizes, progress, and ETA utilities
+- Builder pattern for client configuration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { version = "0.4.40", features = ["serde"] }
 anyhow = "1.0.97"
 thiserror = "2.0.12"
 log = "0.4.27"
+tokio = { version = "1", features = ["sync"] }
 byte-unit = "5.1.6"
 
 [dev-dependencies]

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -4,7 +4,7 @@ use syno_download_station::client::SynoDS;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    let mut synods = {
+    let synods = {
         let url = env::var("SYNOLOGY_URL")?;
         let username = env::var("SYNOLOGY_USERNAME")?;
         let password = env::var("SYNOLOGY_PASSWORD")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<()> {
-//!     let mut synods = {
+//!     let synods = {
 //!         let url = env::var("SYNOLOGY_URL")?;
 //!         let username = env::var("SYNOLOGY_USERNAME")?;
 //!         let password = env::var("SYNOLOGY_PASSWORD")?;

--- a/test-files/api_error.json
+++ b/test-files/api_error.json
@@ -1,0 +1,6 @@
+{
+  "success": false,
+  "error": {
+    "code": 403
+  }
+}

--- a/test-files/auth_error.json
+++ b/test-files/auth_error.json
@@ -1,0 +1,6 @@
+{
+  "success": false,
+  "error": {
+    "code": 400
+  }
+}

--- a/test-files/session_expired.json
+++ b/test-files/session_expired.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": 119
+  },
+  "success": false
+}


### PR DESCRIPTION
Added transparent session token refresh on API error code 119 (session expired), automatically re-authorizing and retrying the failed request.
Also fixed inconsistent error handling: previously, the majority of the public methods silently dropped the Synology error.code from failed API responses, returning generic string errors that prevented programmatic error handling.