### PR TITLE
Added functionality to accept invalid/self-signed certificates

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -71,7 +71,13 @@ impl SynoDS {
     /// - Username, password, or host URL is empty
     /// - URL doesn't start with "http://" or "https://"
     #[allow(clippy::needless_pass_by_value)]
-    pub fn new(url: String, username: String, password: String, timeout_ms: u64) -> Result<Self> {
+    pub fn new(
+        url: String,
+        username: String,
+        password: String,
+        timeout_ms: u64,
+        accept_invalid_certs: bool,
+    ) -> Result<Self> {
         // Validate all required configuration parameters
         if username.is_empty() {
             return Err(Configuration("Username cannot be empty".into()).into());
@@ -96,7 +102,7 @@ impl SynoDS {
         // Remove trailing slash from host URL if present
         let url = url.trim_end_matches('/').to_string();
 
-        let client = Self::create_client(timeout_ms);
+        let client = Self::create_client(timeout_ms, accept_invalid_certs);
 
         Ok(Self {
             url,
@@ -108,9 +114,10 @@ impl SynoDS {
     }
 
     /// Creates a configured HTTP client
-    fn create_client(timeout: u64) -> Client {
+    fn create_client(timeout: u64, accept_invalid_certs: bool) -> Client {
         Client::builder()
             .timeout(Duration::from_millis(timeout))
+            .danger_accept_invalid_certs(accept_invalid_certs)
             .build()
             .unwrap_or_default()
     }
@@ -730,6 +737,7 @@ pub struct SynoDSBuilder {
     username: Option<String>,
     password: Option<String>,
     timeout: Option<u64>,
+    accept_invalid_certs: bool,
 }
 
 impl SynoDSBuilder {
@@ -761,6 +769,13 @@ impl SynoDSBuilder {
         self
     }
 
+    /// Sets whether to accept invalid/self-signed certificates
+    #[must_use]
+    pub fn danger_accept_invalid_certs(mut self, accept: bool) -> Self {
+        self.accept_invalid_certs = accept;
+        self
+    }
+
     /// Builds the [`SynoDS`] client
     ///
     /// # Errors
@@ -782,7 +797,7 @@ impl SynoDSBuilder {
 
         let timeout = self.timeout.unwrap_or(3000);
 
-        let client = SynoDS::new(url, username, password, timeout)?;
+        let client = SynoDS::new(url, username, password, timeout, self.accept_invalid_certs)?;
 
         Ok(client)
     }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -702,3 +702,35 @@ async fn test_clear_completed_error_preserves_code() {
         other => panic!("Expected SynoError::Api with code 403, got: {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn test_client_builds_with_accept_invalid_certs() {
+    let result = SynoDS::builder()
+        .url("https://nas:5001")
+        .username("user")
+        .password("pass")
+        .danger_accept_invalid_certs(true)
+        .build();
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_accept_invalid_certs_can_make_request() {
+    let (mut server, _) = setup_client().await;
+
+    // Build a client with accept_invalid_certs enabled
+    let synods = SynoDS::builder()
+        .url("https://nas:5001")
+        .username("test")
+        .password("test123")
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+
+    create_login_mock(&mut server).await;
+
+    // Verify the client can still make requests normally
+    let result = synods.authorize().await;
+    assert!(result.is_ok());
+    assert!(synods.is_authorized().await);
+}

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -716,11 +716,11 @@ async fn test_client_builds_with_accept_invalid_certs() {
 
 #[tokio::test]
 async fn test_accept_invalid_certs_can_make_request() {
-    let (mut server, _) = setup_client().await;
+    let mut server = MockServer::start().await;
 
-    // Build a client with accept_invalid_certs enabled
+    // Build client with accept_invalid_certs enabled
     let synods = SynoDS::builder()
-        .url("https://nas:5001")
+        .url(server.uri())
         .username("test")
         .password("test123")
         .danger_accept_invalid_certs(true)
@@ -729,8 +729,9 @@ async fn test_accept_invalid_certs_can_make_request() {
 
     create_login_mock(&mut server).await;
 
-    // Verify the client can still make requests normally
     let result = synods.authorize().await;
     assert!(result.is_ok());
     assert!(synods.is_authorized().await);
+
+    server.verify().await;
 }


### PR DESCRIPTION
Hi,

I'm in the process of porting my dstui app to your crate because my own implementation of the API calls are not too... let's say, elegant :)

Came across a feature that I miss from the crate, however. My downloadstation is operating only on my local network so I'm using a self-signed certificate to login via https and the crate fails to authenticate (correctly). Therefore I added an additional option to disable the cert validation so I will still be able to authenticate through https. I included the word `danger` in the function name to make it clear that this is unsafe territory.

Hope you will think this is a useful addition. Full disclosure: I used Claude to generate the test cases.

